### PR TITLE
Updated to use stdin/stdout, fixes for packet processing

### DIFF
--- a/defragv6.go
+++ b/defragv6.go
@@ -26,7 +26,7 @@ type fragmentList struct {
 	LastSeen      time.Time
 }
 
-var debug debugging = true // or flip to false
+var debug debugging = false // or flip to false
 type debugging bool
 
 func (d debugging) Printf(format string, args ...interface{}) {

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func (h *dnsStream) createPacket(msg_buf []byte, normalPack chan gopacket.Packet
 		ip_checksum := layers.IPv4{}
 		ip_checksum.Version = 4
 		// XXX: TTL should be copied from the original packets somehow
-		ip_checksum.TTL = 1
+		ip_checksum.TTL = 64
 		ip_checksum.SrcIP = h.net.Src().Raw()
 		ip_checksum.DstIP = h.net.Dst().Raw()
 		udpLayer.SetNetworkLayerForChecksum(&ip_checksum)
@@ -240,7 +240,7 @@ func (h *dnsStream) createPacket(msg_buf []byte, normalPack chan gopacket.Packet
 		ip6_checksum.Version = 6
 		ip6_checksum.NextHeader = layers.IPProtocolNoNextHeader
 		// XXX: HopLimit should be copied from the original packets somehow
-		ip6_checksum.HopLimit = 1
+		ip6_checksum.HopLimit = 64
 		ip6_checksum.SrcIP = h.net.Src().Raw()
 		ip6_checksum.DstIP = h.net.Dst().Raw()
 		udpLayer.SetNetworkLayerForChecksum(&ip6_checksum)
@@ -267,7 +267,7 @@ func (h *dnsStream) createPacket(msg_buf []byte, normalPack chan gopacket.Packet
 			Flags:      0,
 			FragOffset: 0,
 			// XXX: TTL should be copied from the original packets somehow
-			TTL:      1,
+			TTL:      64,
 			Protocol: layers.IPProtocolUDP,
 			Checksum: 0,
 			SrcIP:    h.net.Src().Raw(),
@@ -309,7 +309,7 @@ func (h *dnsStream) createPacket(msg_buf []byte, normalPack chan gopacket.Packet
 			Length:       0,
 			NextHeader:   layers.IPProtocolNoNextHeader, //no sure what next header should be used there
 			// XXX: HopLimit should be copied from the original packets somehow
-			HopLimit: 1,
+			HopLimit: 64,
 			SrcIP:    h.net.Src().Raw(),
 			DstIP:    h.net.Dst().Raw(),
 			HopByHop: nil,

--- a/main.go
+++ b/main.go
@@ -266,13 +266,14 @@ func (h *dnsStream) createPacket(msg_buf []byte, normalPack chan gopacket.Packet
 			Id:         0,
 			Flags:      0,
 			FragOffset: 0,
-			TTL:        0,
-			Protocol:   layers.IPProtocolUDP,
-			Checksum:   0,
-			SrcIP:      h.net.Src().Raw(),
-			DstIP:      h.net.Dst().Raw(),
-			Options:    []layers.IPv4Option{},
-			Padding:    []byte{},
+			// XXX: TTL should be copied from the original packets somehow
+			TTL:      1,
+			Protocol: layers.IPProtocolUDP,
+			Checksum: 0,
+			SrcIP:    h.net.Src().Raw(),
+			DstIP:    h.net.Dst().Raw(),
+			Options:  []layers.IPv4Option{},
+			Padding:  []byte{},
 		}
 		//serialize it and use the serialize buffer to new packet
 		IPserializeBuffer := gopacket.NewSerializeBuffer()
@@ -307,10 +308,11 @@ func (h *dnsStream) createPacket(msg_buf []byte, normalPack chan gopacket.Packet
 			FlowLabel:    0,
 			Length:       0,
 			NextHeader:   layers.IPProtocolNoNextHeader, //no sure what next header should be used there
-			HopLimit:     0,
-			SrcIP:        h.net.Src().Raw(),
-			DstIP:        h.net.Dst().Raw(),
-			HopByHop:     nil,
+			// XXX: HopLimit should be copied from the original packets somehow
+			HopLimit: 1,
+			SrcIP:    h.net.Src().Raw(),
+			DstIP:    h.net.Dst().Raw(),
+			HopByHop: nil,
 			// hbh will be pointed to by HopByHop if that layer exists.
 		}
 		IPserializeBuffer := gopacket.NewSerializeBuffer()

--- a/main.go
+++ b/main.go
@@ -230,7 +230,8 @@ func (h *dnsStream) createPacket(msg_buf []byte, normalPack chan gopacket.Packet
 	if h.net.EndpointType() == layers.EndpointIPv4 {
 		ip_checksum := layers.IPv4{}
 		ip_checksum.Version = 4
-		ip_checksum.TTL = 0
+		// XXX: TTL should be copied from the original packets somehow
+		ip_checksum.TTL = 1
 		ip_checksum.SrcIP = h.net.Src().Raw()
 		ip_checksum.DstIP = h.net.Dst().Raw()
 		udpLayer.SetNetworkLayerForChecksum(&ip_checksum)
@@ -238,7 +239,8 @@ func (h *dnsStream) createPacket(msg_buf []byte, normalPack chan gopacket.Packet
 		ip6_checksum := layers.IPv6{}
 		ip6_checksum.Version = 6
 		ip6_checksum.NextHeader = layers.IPProtocolNoNextHeader
-		ip6_checksum.HopLimit = 0
+		// XXX: HopLimit should be copied from the original packets somehow
+		ip6_checksum.HopLimit = 1
 		ip6_checksum.SrcIP = h.net.Src().Raw()
 		ip6_checksum.DstIP = h.net.Dst().Raw()
 		udpLayer.SetNetworkLayerForChecksum(&ip6_checksum)

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,7 @@ func TestnotFrag(t *testing.T) {
 	}
 	ip.SerializeTo(b, ops)
 	pack := gopacket.NewPacket(b.Bytes(), layers.LinkTypeIPv4, gopacket.Default)
-	_, err := v4Defrag(v4defragger, pack)
+	_, err := v4defragger.DefragIPv4(pack.Layer(layers.LayerTypeIPv4).(*layers.IPv4))
 	if err != nil {
 		t.Errorf("v4defrag do not return err when no frag pack is in")
 	}
@@ -41,35 +41,35 @@ func Testv4Defrag(t *testing.T) {
 	pack2 := gopacket.NewPacket(testPing1Frag2, layers.LinkTypeEthernet, gopacket.Default)
 	pack3 := gopacket.NewPacket(testPing1Frag3, layers.LinkTypeEthernet, gopacket.Default)
 	pack4 := gopacket.NewPacket(testPing1Frag4, layers.LinkTypeEthernet, gopacket.Default)
-	result, err := v4Defrag(v4defragger, pack1)
+	result, err := v4defragger.DefragIPv4(pack1.Layer(layers.LayerTypeIPv4).(*layers.IPv4))
 	if err != nil {
 		t.Fatalf("error defragmenting pack1")
 	}
 	if result != nil {
 		t.Fatalf("unexpected defragmented packet after pack1")
 	}
-	result, err = v4Defrag(v4defragger, pack2)
+	result, err = v4defragger.DefragIPv4(pack2.Layer(layers.LayerTypeIPv4).(*layers.IPv4))
 	if err != nil {
 		t.Fatalf("error defragmenting pack2")
 	}
 	if result != nil {
 		t.Fatalf("unexpected defragmented packet after pack2")
 	}
-	result, err = v4Defrag(v4defragger, pack3)
+	result, err = v4defragger.DefragIPv4(pack3.Layer(layers.LayerTypeIPv4).(*layers.IPv4))
 	if err != nil {
 		t.Fatalf("error defragmenting pack3")
 	}
 	if result != nil {
 		t.Fatalf("unexpected defragmented packet after pack3")
 	}
-	result, err = v4Defrag(v4defragger, pack4)
+	result, err = v4defragger.DefragIPv4(pack4.Layer(layers.LayerTypeIPv4).(*layers.IPv4))
 	if err != nil {
 		t.Fatalf("error defragmenting pack4")
 	}
 	if result == nil {
 		t.Fatalf("missing defragmented packet after pack4")
 	}
-	ip := result.Layer(layers.LayerTypeIPv4)
+	ip := result
 	// TEST if the ip matches expectation
 	if ip == nil {
 		t.Errorf("defrag does not return IPV4 LAYER")


### PR DESCRIPTION
This allows stdin/stdout if a "-" is used for a file name. We have to change to `pcapgo` instead of `pcap` as our file reader for this. 
